### PR TITLE
Set recreateClosed=true

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,7 @@
     "github>anguslees/renovate-config",
     "schedule:weekly"
   ],
+  "recreateClosed": true,
   "packageRules": [
     {
       "matchPackagePatterns": [


### PR DESCRIPTION
Unsure why the automatic behaviour isn't working, but the renovatebot logs indicate many changes are not being turned into PRs because recreateClosed is false.  Force it to true, to see if that helps.